### PR TITLE
Fix spack build

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ Note that `CMAKE_PREFIX_PATH` is specified in the `spack-config` so this is requ
 
 ## Sample Run
 
+### Spack
+
+```bash
+$ spack load access-test-model
+$ mpirun -n 6 $(which hello_world.exe)
+ Hello World from process:            1 of            6
+ Hello World from process:            2 of            6
+ Hello World from process:            3 of            6
+ Hello World from process:            4 of            6
+ Hello World from process:            5 of            6
+ Hello World from process:            0 of            6
+```
+
+### Direct
 ```bash
 $ mpirun -n 6 build/hello_world.exe 
  Hello World from process:            0 of            6

--- a/stub/CMakeLists.txt
+++ b/stub/CMakeLists.txt
@@ -16,6 +16,6 @@ message("---- CMAKE_Fortran_COMPILER: " ${CMAKE_Fortran_COMPILER})
 
 # Source code
 add_executable(hello_world.exe src/hello_world.f90)
-target_link_libraries(hello_world.exe PUBLIC MPI::MPI_Fortran)
+target_link_libraries(hello_world.exe)
 
 install(TARGETS hello_world.exe     DESTINATION "bin")


### PR DESCRIPTION
Having issues with the spack build not working

```bash
spack install access-test-model@git.567fe8a0da32d3c6ccfc36b21b9ca945d1d82a47%intel@2021.10.0
```

```bash
4 errors found in build log:
     29    Scanning dependencies of target hello_world.exe
     30    make[2]: Leaving directory '/scratch/yy00/xxx999/tmp/spack-stage/spack-stage-access-test-model-git.567fe8a0da32d3c6c
           cfc36b21b9ca945d1d82a47_0-git.13-gqzfwtfj3cbbdwl4763ycuf2pmrymycc/spack-build-gqzfwtf'
     31    make  -f CMakeFiles/hello_world.exe.dir/build.make CMakeFiles/hello_world.exe.dir/build
     32    make[2]: Entering directory '/scratch/yy00/xxx999/tmp/spack-stage/spack-stage-access-test-model-git.567fe8a0da32d3c6
           ccfc36b21b9ca945d1d82a47_0-git.13-gqzfwtfj3cbbdwl4763ycuf2pmrymycc/spack-build-gqzfwtf'
     33    [ 50%] Building Fortran object CMakeFiles/hello_world.exe.dir/src/hello_world.f90.o
     34    /apps/openmpi/4.1.5/bin/mpif90  -I/apps/openmpi-mofed5.8-pbs2021.1/4.1.5/include -I/apps/openmpi/4.1.5/include/GNU -
           O3 -pthread -c /scratch/yy00/xxx999/tmp/spack-stage/spack-stage-access-test-model-git.567fe8a0da32d3c6ccfc36b21b9ca9
           45d1d82a47_0-git.13-gqzfwtfj3cbbdwl4763ycuf2pmrymycc/spack-src/stub/src/hello_world.f90 -o CMakeFiles/hello_world.ex
           e.dir/src/hello_world.f90.o
  >> 35    /scratch/yy00/xxx999/tmp/spack-stage/spack-stage-access-test-model-git.567fe8a0da32d3c6ccfc36b21b9ca945d1d82a47_0-gi
           t.13-gqzfwtfj3cbbdwl4763ycuf2pmrymycc/spack-src/stub/src/hello_world.f90(5): error #7013: This module file was not g
           enerated by any release of this compiler.   [MPI]
     36    use mpi
     37    ----^
     38    compilation aborted for /scratch/yy00/xxx999/tmp/spack-stage/spack-stage-access-test-model-git.567fe8a0da32d3c6ccfc3
           6b21b9ca945d1d82a47_0-git.13-gqzfwtfj3cbbdwl4763ycuf2pmrymycc/spack-src/stub/src/hello_world.f90 (code 1)
  >> 39    make[2]: *** [CMakeFiles/hello_world.exe.dir/build.make:78: CMakeFiles/hello_world.exe.dir/src/hello_world.f90.o] Er
           ror 1
     40    make[2]: Leaving directory '/scratch/yy00/xxx999/tmp/spack-stage/spack-stage-access-test-model-git.567fe8a0da32d3c6c
           cfc36b21b9ca945d1d82a47_0-git.13-gqzfwtfj3cbbdwl4763ycuf2pmrymycc/spack-build-gqzfwtf'
  >> 41    make[1]: *** [CMakeFiles/Makefile2:86: CMakeFiles/hello_world.exe.dir/all] Error 2
     42    make[1]: Leaving directory '/scratch/yy00/xxx999/tmp/spack-stage/spack-stage-access-test-model-git.567fe8a0da32d3c6c
           cfc36b21b9ca945d1d82a47_0-git.13-gqzfwtfj3cbbdwl4763ycuf2pmrymycc/spack-build-gqzfwtf'
  >> 43    make: *** [Makefile:139: all] Error 2
```

It's pretty clear that issue is that there is a GNU path getting injected: `-I/apps/openmpi/4.1.5/include/GNU`

Not sure why ...